### PR TITLE
change version of goolf v1.6.5 to goolf v1.5.14, to align with existing gompi 1.5.12 easyconfig

### DIFF
--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-1.5.14.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-1.5.14.eb
@@ -5,7 +5,7 @@ homepage = 'http://www.fftw.org'
 description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
  in one or more dimensions, of arbitrary input size, and of both real and complex data."""
 
-toolchain = {'name': 'gompi', 'version': '1.6.5'}
+toolchain = {'name': 'gompi', 'version': '1.5.14'}
 toolchainopts = {'optarch': True, 'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/g/gompi/gompi-1.5.14.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-1.5.14.eb
@@ -1,7 +1,7 @@
 easyblock = "Toolchain"
 
 name = 'gompi'
-version = '1.6.5'
+version = '1.5.14'
 
 homepage = '(none)'
 description = """GNU Compiler Collection (GCC) based compiler toolchain,

--- a/easybuild/easyconfigs/g/goolf/goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/g/goolf/goolf-1.5.14.eb
@@ -1,7 +1,7 @@
 easyblock = "Toolchain"
 
 name = 'goolf'
-version = '1.6.5'
+version = '1.5.14'
 
 homepage = '(none)'
 description = """GNU Compiler Collection (GCC) based compiler toolchain, including
@@ -28,7 +28,7 @@ comp_mpi_tc = (comp_mpi_tc_name, comp_mpi_tc_ver)
 # because of toolchain preperation functions
 dependencies = [
     ('GCC', '4.8.2'),
-    ('OpenMPI', '1.6.5', '', comp),  # part of gompi-1.1.0
+    ('OpenMPI', '1.6.5', '', comp),  # part of gompi
     (blaslib, blasver, blassuff, comp_mpi_tc),
     ('FFTW', '3.3.4', '', comp_mpi_tc),
     ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc),

--- a/easybuild/easyconfigs/g/gzip/gzip-1.6-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/g/gzip/gzip-1.6-goolf-1.5.14.eb
@@ -16,7 +16,7 @@ version = '1.6'
 homepage = 'http://www.gnu.org/software/gzip/'
 description = "gzip (GNU zip) is a popular data compression program as a replacement for compress"
 
-toolchain = {'name': 'goolf', 'version': '1.6.5'}
+toolchain = {'name': 'goolf', 'version': '1.5.14'}
 
 # eg. http://ftp.gnu.org/gnu/gzip/gzip-1.6.tar.gz
 source_urls = [GNU_SOURCE]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.5.14-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.8-gompi-1.5.14-LAPACK-3.5.0.eb
@@ -7,7 +7,7 @@ versionsuffix = '-LAPACK-%s' % lapackver
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
-toolchain = {'name': 'gompi', 'version': '1.6.5'}
+toolchain = {'name': 'gompi', 'version': '1.5.14'}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-1.5.14-OpenBLAS-0.2.8-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-1.5.14-OpenBLAS-0.2.8-LAPACK-3.5.0.eb
@@ -5,7 +5,7 @@ homepage = 'http://www.netlib.org/scalapack/'
 description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
  redesigned for distributed memory MIMD parallel computers."""
 
-toolchain = {'name': 'gompi', 'version': '1.6.5'}
+toolchain = {'name': 'gompi', 'version': '1.5.14'}
 toolchainopts = {'pic': True}
 
 source_urls = [homepage]


### PR DESCRIPTION
@pescobar: as discussed

It makes a lot of sense since we already have a `gompi` 1.5.12 (no `goolf` though) that combines GCC 4.8.1 with OpenMPI 1.6.5...
