### PR TITLE
remove modextravars/modextrapaths from FreeSurfer 6.0.0 easyconfig + add checksums

### DIFF
--- a/easybuild/easyconfigs/f/FreeSurfer/FreeSurfer-6.0.0-centos6_x86_64.eb
+++ b/easybuild/easyconfigs/f/FreeSurfer/FreeSurfer-6.0.0-centos6_x86_64.eb
@@ -12,33 +12,15 @@ source_urls = [
     'ftp://surfer.nmr.mgh.harvard.edu/pub/dist/%(namelower)s/%(version)s',
     'http://surfer.nmr.mgh.harvard.edu/fswiki/MatlabRuntime?action=AttachFile&do=get&target='
 ]
-
 sources = [
     '%(namelower)s-Linux%(versionsuffix)s-stable-pub-v%(version)s.tar.gz',
     'runtime2012bLinux.tar.gz'
 ]
-
-# see https://surfer.nmr.mgh.harvard.edu/fswiki/SetupConfiguration_Linux
-modextravars = { 
-    'FREESURFER_HOME': '$root',
-    'FSFAST_HOME': '$root/fsfast',
-    'FSF_OUTPUT_FORMAT': 'nii.gz',
-    'SUBJECTS_DIR': '$root/subjects',
-    'MNI_DIR': '$root/mni',
-    'FS_OVERRIDE': '0',
-    'PERL5LIB': '$root/mni/lib/perl5/5.8.5',
-    'OS': 'linux',
-    'MNI_PERL5LIB': '$root/mni/lib/perl5/5.8.5',
-    'FMRI_ANALYSIS_DIR': '$root/fsfast',
-    'MINC_BIN_DIR': '$root/mni/bin',
-    'MINC_LIB_DIR': '$root/mni/lib',
-    'MNI_DIR': '$root/mni',
-    'MNI_DATAPATH': '$root/mni/data',
-}
-
-modextrapaths = {
-     'PATH': 'bin:$root/tktools:$root/fsfast/bin:$root/mni/bin',
-}
+checksums = [
+    # freesurfer-Linux-centos6_x86_64-stable-pub-v6.0.0.tar.gz
+    '9e68ee3fbdb80ab73d097b9c8e99f82bf4674397a1e59593f42bb78f1c1ad449',
+    '3ef4231d566fca45436eda03ae3bb93ffa7af0974a48112348c0d76c62b5fa64',  # runtime2012bLinux.tar.gz
+]
 
 postinstallcmds = ['cp -a %(builddir)s/MCRv80/ %(installdir)s']
 


### PR DESCRIPTION
update for https://github.com/easybuilders/easybuild-easyconfigs/pull/4292, see also https://github.com/easybuilders/easybuild-easyblocks/pull/1543